### PR TITLE
Remove call to cable_ready.clear_turbolink_cache

### DIFF
--- a/app/reflexes/layout_reflex.rb
+++ b/app/reflexes/layout_reflex.rb
@@ -3,7 +3,5 @@
 class LayoutReflex < ApplicationReflex
   def set_layout
     session[:layout] = element.dataset[:layout]
-
-    cable_ready.clear_turbolinks_cache
   end
 end


### PR DESCRIPTION
When trying to change the layout, the layout doesn't change and the following error is logged to the console:
![boxdrop_error](https://user-images.githubusercontent.com/87677429/209924175-48459855-293e-4e6e-8b14-0fcb8162f04e.png)

Basically there's no `clear_turbolink_cache` method defined in the `cable_ready` object which is what's causing the error.
This PR removes the call to `clear_turbolink_cache`